### PR TITLE
Fix bug where update mutation nullifies unset fields

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -14,6 +14,7 @@
     "graphql": "^15.0.0",
     "graphql-cli": "^3.0.14",
     "graphql-relay": "^0.6.0",
+    "lodash": "^4.17.15",
     "lodash-id": "^0.14.0",
     "lowdb": "^1.0.0"
   },

--- a/server/src/book.ts
+++ b/server/src/book.ts
@@ -1,4 +1,5 @@
 import { toGlobalId, fromGlobalId } from "graphql-relay";
+import _ from "lodash";
 import db from "./db";
 
 /**
@@ -6,10 +7,10 @@ import db from "./db";
  */
 interface Book {
   id: string;
-  name?: string;
-  numPages?: number;
-  currentPageNum?: number;
-  lastReadAt?: string; // Lowdb stores dates as strings
+  name?: string | null;
+  numPages?: number | null;
+  currentPageNum?: number | null;
+  lastReadAt?: string | null; // Lowdb stores dates as strings
 }
 
 type CreateBookInput = Omit<Book, "id">;
@@ -54,14 +55,17 @@ function transformCreateInputToInternalBook(
 }
 
 function transformUpdateInputToInternalBook(input: UpdateBookInput): Book {
-  return {
-    ...input,
+  const internalBook: Book = {
+    ..._.omitBy(input, _.isUndefined),
     id: fromGlobalIdOrThrow(input.id),
-    // Ensure dates are actually dates
-    lastReadAt: input.lastReadAt
-      ? new Date(input.lastReadAt).toISOString()
-      : undefined,
   };
+
+  // Ensure dates are actually dates
+  if (input.lastReadAt) {
+    internalBook.lastReadAt = new Date(input.lastReadAt).toISOString();
+  }
+
+  return internalBook;
 }
 
 // Book CRUD


### PR DESCRIPTION
Fixes #11.

* Inputs with fields set to null will be nullified in the db.
* Unset fields will be untouched.

## Test plan

1. Begin with a created book
	![image](https://user-images.githubusercontent.com/12784593/83621983-f8395700-a5c1-11ea-9050-47436ae643f6.png)

1. Update with null and unset fields. Confirm results: updated fields updated, numPages nullified, others untouched.
	![image](https://user-images.githubusercontent.com/12784593/83621990-fc657480-a5c1-11ea-8112-919b6727ccaf.png)