### PR TITLE
Implement bookConnection query

### DIFF
--- a/server/src/book.ts
+++ b/server/src/book.ts
@@ -1,4 +1,10 @@
-import { toGlobalId, fromGlobalId } from "graphql-relay";
+import {
+  toGlobalId,
+  fromGlobalId,
+  connectionFromArray,
+  ConnectionCursor,
+  Connection,
+} from "graphql-relay";
 import _ from "lodash";
 import db from "./db";
 
@@ -79,6 +85,15 @@ const bookCollection = db.defaults({ books: [] }).get("books");
 export function getAllBooks(): Book[] {
   const books: Book[] = bookCollection.value();
   return books.map((book) => transformToExternalBook(book));
+}
+
+export function getAllBooksPaginated(
+  before: ConnectionCursor,
+  after: ConnectionCursor,
+  first: number,
+  last: number
+): Connection<Book> {
+  return connectionFromArray(getAllBooks(), { before, after, first, last });
 }
 
 export function createBook(input: CreateBookInput): Book {

--- a/server/src/resolvers.ts
+++ b/server/src/resolvers.ts
@@ -1,7 +1,12 @@
 import { gql, IResolvers } from "apollo-server-express";
-import { getAllBooks, createBook, updateBook, deleteBook } from "./book";
+import {
+  getAllBooks,
+  createBook,
+  updateBook,
+  deleteBook,
+  getAllBooksPaginated,
+} from "./book";
 
-// TODO: bookConnection: BookConnection
 export const typeDefs = gql`
   type Book {
     id: ID!
@@ -11,8 +16,31 @@ export const typeDefs = gql`
     lastReadAt: String
   }
 
+  type PageInfo {
+    hasNextPage: Boolean!
+    hasPreviousPage: Boolean!
+    startCursor: String
+    endCursor: String
+  }
+
+  type BookConnection {
+    pageInfo: PageInfo!
+    edges: [BookEdge!]!
+  }
+
+  type BookEdge {
+    node: Book!
+    cursor: String!
+  }
+
   type Query {
     books: [Book]
+    bookConnection(
+      before: String
+      after: String
+      first: Int
+      last: Int
+    ): BookConnection!
   }
 
   input CreateBookInput {
@@ -40,6 +68,8 @@ export const typeDefs = gql`
 export const resolvers: IResolvers = {
   Query: {
     books: () => getAllBooks(),
+    bookConnection: (_, { before, after, first, last }) =>
+      getAllBooksPaginated(before, after, first, last),
   },
 
   Mutation: {


### PR DESCRIPTION
## Summary

Implement forward pagination using a graphql-relay function. Conforms to the connection spec https://relay.dev/graphql/connections.htm.

This will not scale to larger datasets, as we are loading all data into memory (using the same function as the `books` query) before filtering them for pagination.

This uses limit/offset pagination, and so inherits all its flaws. This should be okay for our use case, as the user is the only person updating their own list of books and we are considering having multiple devices as an edge case.

Resolves #17.

## Test plan

1. Empty list
	![image](https://user-images.githubusercontent.com/12784593/83625838-2705fc00-a5c7-11ea-93e1-e3a955f6752b.png)

1. With unfiltered results (observe no query args)
	![image](https://user-images.githubusercontent.com/12784593/83625858-2e2d0a00-a5c7-11ea-96f3-b64f547bad0e.png)

1. `first` argument provided
	![image](https://user-images.githubusercontent.com/12784593/83625935-4d2b9c00-a5c7-11ea-96ee-cf3176d564cd.png)

1. `first` and `after` cursor provided, simulating a request for a second page.
	![image](https://user-images.githubusercontent.com/12784593/83626112-8fed7400-a5c7-11ea-806c-0a460deb09b4.png)
