### PR TITLE
Allow non-localhost to connect to server

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -7,6 +7,6 @@ const server = new ApolloServer({ typeDefs, resolvers });
 const app = express();
 server.applyMiddleware({ app });
 
-app.listen({ port: 4000 }, () =>
+app.listen({ host: "0.0.0.0", port: 4000 }, () =>
   console.log(`🚀 Server ready at http://localhost:4000${server.graphqlPath}`)
 );


### PR DESCRIPTION
If testing on a device, you'll likely also need to change `localhost:4000` to `<your computer's local IP address>:4000` in Environment.ts. @chirag-singhal @manyaagarwal 

## Test plan

Checked that going to `http://<local IP>:4000/graphql` did not work in the past but works now.